### PR TITLE
Add feature flag for automatic backup

### DIFF
--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -72,9 +72,11 @@ android {
                 testCoverageEnabled = coverage == "true"
             }
             buildConfigField "boolean", "ONE_WAY_BROADCAST", "true"
+            buildConfigField "boolean", "automatic_backup_restore", "true"
         }
         release {
             buildConfigField "boolean", "ONE_WAY_BROADCAST", "true"
+            buildConfigField "boolean", "automatic_backup_restore", "true"
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -37,6 +37,7 @@ import com.airbnb.mvrx.Mavericks
 import com.airbnb.mvrx.viewModel
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
+import im.vector.app.BuildConfig
 import im.vector.app.R
 import im.vector.app.SpaceStateHandler
 import im.vector.app.core.extensions.hideKeyboard
@@ -605,11 +606,16 @@ class HomeActivity :
     override fun onStart() {
         super.onStart()
 
-        // Check if there is a backup and start creating backup if not enabled
-        startKeyBackupOperations()
 
-        // restore backup if available
-        recoverKeyBackup()
+
+        if (BuildConfig.automatic_backup_restore) {
+            // Check if there is a backup and start creating backup if not enabled
+            startKeyBackupOperations()
+
+            // restore backup if available
+            recoverKeyBackup()
+        }
+
     }
 
     override fun onResume() {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
