### PR TITLE
Added feature flag 'hide_backup_dialog' to control which signout dial…

### DIFF
--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -73,10 +73,12 @@ android {
             }
             buildConfigField "boolean", "ONE_WAY_BROADCAST", "true"
             buildConfigField "boolean", "automatic_backup_restore", "true"
+            buildConfigField "boolean", "hide_backup_dialog", "true"
         }
         release {
             buildConfigField "boolean", "ONE_WAY_BROADCAST", "true"
             buildConfigField "boolean", "automatic_backup_restore", "true"
+            buildConfigField "boolean", "hide_backup_dialog", "true"
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/workers/signout/SignOutUiWorker.kt
+++ b/vector/src/main/java/im/vector/app/features/workers/signout/SignOutUiWorker.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.workers.signout
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import im.vector.app.BuildConfig
 import im.vector.app.R
 import im.vector.app.core.extensions.cannotLogoutSafely
 import im.vector.app.core.extensions.singletonEntryPoint
@@ -36,7 +37,7 @@ class SignOutUiWorker(private val activity: FragmentActivity) {
     }
 
     private fun CoroutineScope.perform(session: Session) = launch {
-        if (session.cannotLogoutSafely()) {
+        if (!BuildConfig.hide_backup_dialog && session.cannotLogoutSafely()) {
             // The backup check on logout flow has to be displayed if there are keys in the store, and the keys backup state is not Ready
             val signOutDialog = SignOutBottomSheetDialogFragment.newInstance()
             signOutDialog.onSignOut = Runnable {
@@ -45,15 +46,19 @@ class SignOutUiWorker(private val activity: FragmentActivity) {
             signOutDialog.show(activity.supportFragmentManager, "SO")
         } else {
             // Display a simple confirmation dialog
-            MaterialAlertDialogBuilder(activity)
-                    .setTitle(R.string.action_sign_out)
-                    .setMessage(R.string.action_sign_out_confirmation_simple)
-                    .setPositiveButton(R.string.action_sign_out) { _, _ ->
-                        doSignOut()
-                    }
-                    .setNegativeButton(R.string.action_cancel, null)
-                    .show()
+            displaySimpleConfirmationDialog()
         }
+    }
+
+    private fun displaySimpleConfirmationDialog() {
+        MaterialAlertDialogBuilder(activity)
+                .setTitle(R.string.action_sign_out)
+                .setMessage(R.string.action_sign_out_confirmation_simple)
+                .setPositiveButton(R.string.action_sign_out) { _, _ ->
+                    doSignOut()
+                }
+                .setNegativeButton(R.string.action_cancel, null)
+                .show()
     }
 
     private fun doSignOut() {


### PR DESCRIPTION
…og message the user receives

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
